### PR TITLE
Trim Whitespaces + prevent Zoom on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -134,7 +134,13 @@ button {
   width: 50vw;
 }
 
+/**
+* We want to maintain 16px on small devices to prevent zoom-on-focus effects
+* on iphone and other Apple devices
+ */
 @media screen and (max-width: 800px) {
+  body { font-size: 16px; }
+  input, select { font-size: 100%; }
   .word-card {
     width: 80vw;
   }

--- a/src/App.js
+++ b/src/App.js
@@ -37,13 +37,13 @@ function App() {
 
   const handleChinese = () => {
     return words.filter(wordObject => {
-      return wordObject.译本译词.toLowerCase().includes(searchTerm);
+      return wordObject.译本译词.toLowerCase().includes(searchTerm.trim());
     });
   }
 
   const handleEnglish = () => {
     return words.filter(wordObject => {
-      return wordObject.原词.toLowerCase().includes(searchTerm);
+      return wordObject.原词.toLowerCase().includes(searchTerm.trim());
     });
   }
 


### PR DESCRIPTION
1. trim whitespace when filtering words
2. prevent iPhones from zooming when focussing on input fields